### PR TITLE
Add Tkinter GUI for browsing reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
 # ReportFileDB
+
+ReportFileDB 是一個簡易的 SQLite 工具，協助你把常用的報告全文直接存進資料庫，
+並透過類似同人圖庫（Danbooru）的樹狀子母標籤快速檢索舊資料。
+
+## 功能特色
+
+- ✅ 支援整篇報告或文件全文存放，懶得切段也沒問題。
+- ✅ 可建立任意深度的標籤父子關係，搜尋父標籤時自動包含所有子孫標籤。
+- ✅ 以 CLI 或 GUI 操作：新增報告、維護標籤、依標籤搜尋、匯出報告。
+
+## 安裝與使用
+
+1. 建議使用 Python 3.11 或更新版本。
+2. 使用 CLI：
+
+```bash
+python -m reportdb_cli add-report "四月月報" --file ./reports/2024-04.md --tag 月報 --tag 財報
+python -m reportdb_cli add-tag "財報/收入" --parent 財報
+python -m reportdb_cli assign-tag 1 --tag "財報/收入"
+python -m reportdb_cli search --tag 財報
+```
+
+`add-report` 指令支援 `--content`、`--file` 或 `--stdin`（從標準輸入讀取）。
+
+3. 若想用圖形化介面，直接啟動 GUI：
+
+```bash
+python -m reportdb_gui
+```
+
+GUI 介面提供左側標籤樹與右側報告清單，可直接新增報告、建立標籤並匯出報告。
+
+## 指令列表
+
+| 指令 | 說明 |
+| --- | --- |
+| `add-report` | 新增報告，支援一次設定多個標籤。 |
+| `add-tag` | 新增標籤，可指定父標籤建立子母樹。 |
+| `set-parent` | 調整既有標籤的父標籤。 |
+| `assign-tag` | 為既有報告補上標籤。 |
+| `list-reports` | 列出所有報告，可選擇顯示內容。 |
+| `list-tags` | 以樹狀結構顯示全部標籤。 |
+| `search` | 依指定標籤（含所有子孫）搜尋報告。 |
+| `export` | 將指定報告匯出成檔案。 |
+
+## 開發筆記
+
+- 所有資料存放於同目錄下的 `reportdb.sqlite3`（可用 `--database` 指定其他路徑）。
+- 搜尋時會自動展開標籤的子孫節點，達成類似 Danbooru 的瀏覽體驗。
+- 程式碼使用標準函式庫 `sqlite3`，不需額外安裝套件。

--- a/reportdb_cli.py
+++ b/reportdb_cli.py
@@ -1,0 +1,7 @@
+"""Command line入口，可透過 `python -m reportdb_cli` 使用。"""
+
+from reportfiledb.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reportdb_gui.py
+++ b/reportdb_gui.py
@@ -1,0 +1,7 @@
+"""GUI 入口，可透過 `python -m reportdb_gui` 啟動。"""
+
+from reportfiledb.gui import main
+
+
+if __name__ == "__main__":
+    main()

--- a/reportfiledb/__init__.py
+++ b/reportfiledb/__init__.py
@@ -1,0 +1,5 @@
+"""ReportFileDB package providing tools for storing and retrieving report content with hierarchical tags."""
+
+from .database import ReportDatabase
+
+__all__ = ["ReportDatabase"]

--- a/reportfiledb/cli.py
+++ b/reportfiledb/cli.py
@@ -1,0 +1,191 @@
+"""Command line interface for ReportFileDB."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from .database import ReportDatabase
+
+
+def _print_report(report_db: ReportDatabase, report_id: int, *, show_content: bool) -> None:
+    report = report_db.get_report(report_id)
+    tags = ", ".join(tag.name for tag in report_db.get_tags_for_report(report.id)) or "<無標籤>"
+    print(f"[{report.id}] {report.title} ({report.created_at.isoformat()} UTC)")
+    if report.source_path:
+        print(f"  來源: {report.source_path}")
+    print(f"  標籤: {tags}")
+    if show_content:
+        print("  內容:")
+        for line in report.content.splitlines():
+            print(f"    {line}")
+
+
+def _print_tag_tree(report_db: ReportDatabase) -> None:
+    tree = report_db.build_tag_tree()
+
+    def walk(parent_id: Optional[int], prefix: str = "") -> None:
+        children = tree.get(parent_id, [])
+        for index, tag in enumerate(children):
+            connector = "└─" if index == len(children) - 1 else "├─"
+            print(f"{prefix}{connector} {tag.name}")
+            extension = "   " if connector == "└─" else "│  "
+            walk(tag.id, prefix + extension)
+
+    roots = tree.get(None, [])
+    if not roots:
+        print("(尚未建立標籤)")
+        return
+
+    for index, tag in enumerate(roots):
+        connector = "└─" if index == len(roots) - 1 else "├─"
+        print(f"{connector} {tag.name}")
+        extension = "   " if connector == "└─" else "│  "
+        walk(tag.id, extension)
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="報告檢索資料庫管理工具")
+    parser.add_argument(
+        "--database",
+        default="reportdb.sqlite3",
+        help="資料庫檔案路徑 (預設: reportdb.sqlite3)",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # add-report -------------------------------------------------------------
+    add_report = subparsers.add_parser("add-report", help="新增報告內容")
+    add_report.add_argument("title", help="報告標題")
+    content_group = add_report.add_mutually_exclusive_group()
+    content_group.add_argument(
+        "--content", help="直接提供內容文字"
+    )
+    content_group.add_argument(
+        "--file", type=Path, help="從檔案讀取報告內容"
+    )
+    content_group.add_argument(
+        "--stdin", action="store_true", help="從標準輸入讀取內容"
+    )
+    add_report.add_argument(
+        "--tag",
+        action="append",
+        dest="tags",
+        help="要套用的標籤，可重複使用",
+    )
+
+    # add-tag ----------------------------------------------------------------
+    add_tag = subparsers.add_parser("add-tag", help="新增標籤")
+    add_tag.add_argument("name", help="標籤名稱")
+    add_tag.add_argument("--parent", help="父標籤名稱 (如需建立子母標籤)")
+
+    # set-parent -------------------------------------------------------------
+    set_parent = subparsers.add_parser("set-parent", help="調整標籤的父子關係")
+    set_parent.add_argument("name", help="標籤名稱")
+    set_parent.add_argument("--parent", help="新的父標籤名稱，留空表示移除父標籤")
+
+    # assign-tags ------------------------------------------------------------
+    assign = subparsers.add_parser("assign-tag", help="為既有報告指派標籤")
+    assign.add_argument("report_id", type=int, help="報告 ID")
+    assign.add_argument("--tag", action="append", dest="tags", required=True, help="標籤名稱，可重複")
+
+    # list-reports -----------------------------------------------------------
+    list_reports = subparsers.add_parser("list-reports", help="列出所有報告")
+    list_reports.add_argument(
+        "--show-content",
+        action="store_true",
+        help="同時顯示報告內容",
+    )
+
+    # list-tags --------------------------------------------------------------
+    subparsers.add_parser("list-tags", help="以樹狀結構顯示全部標籤")
+
+    # search -----------------------------------------------------------------
+    search = subparsers.add_parser("search", help="依標籤搜尋報告")
+    search.add_argument("--tag", action="append", dest="tags", required=True, help="標籤名稱，可重複")
+    search.add_argument(
+        "--show-content",
+        action="store_true",
+        help="同時顯示內容",
+    )
+
+    # export -----------------------------------------------------------------
+    export = subparsers.add_parser("export", help="匯出報告內容至檔案")
+    export.add_argument("report_id", type=int, help="報告 ID")
+    export.add_argument("destination", type=Path, help="輸出檔案路徑")
+
+    return parser
+
+
+def _read_content_from_args(args: argparse.Namespace) -> str:
+    if args.content is not None:
+        return args.content
+    if args.file is not None:
+        return args.file.read_text(encoding="utf-8")
+    if getattr(args, "stdin", False):
+        return sys.stdin.read()
+    raise SystemExit("請使用 --content、--file 或 --stdin 提供報告內容")
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    parser = create_parser()
+    args = parser.parse_args(argv)
+
+    db = ReportDatabase(args.database)
+
+    if args.command == "add-report":
+        content = _read_content_from_args(args)
+        report_id = db.add_report(args.title, content, tags=args.tags)
+        print(f"已新增報告 #{report_id}")
+        return 0
+
+    if args.command == "add-tag":
+        tag_id = db.ensure_tag(args.name, parent=args.parent)
+        print(f"標籤 '{args.name}' (ID: {tag_id}) 已建立")
+        return 0
+
+    if args.command == "set-parent":
+        db.set_tag_parent(args.name, args.parent)
+        if args.parent:
+            print(f"已將 '{args.name}' 設為 '{args.parent}' 的子標籤")
+        else:
+            print(f"已移除 '{args.name}' 的父標籤設定")
+        return 0
+
+    if args.command == "assign-tag":
+        db.assign_tags(args.report_id, args.tags)
+        print(f"已為報告 #{args.report_id} 新增標籤: {', '.join(args.tags)}")
+        return 0
+
+    if args.command == "list-reports":
+        for report in db.list_reports():
+            _print_report(db, report.id, show_content=args.show_content)
+        return 0
+
+    if args.command == "list-tags":
+        _print_tag_tree(db)
+        return 0
+
+    if args.command == "search":
+        tags = args.tags or []
+        reports = db.search_reports(tags)
+        if not reports:
+            print("找不到符合的報告")
+            return 0
+        for report in reports:
+            _print_report(db, report.id, show_content=args.show_content)
+        return 0
+
+    if args.command == "export":
+        destination = db.export_report(args.report_id, args.destination)
+        print(f"已匯出至 {destination}")
+        return 0
+
+    parser.error("未知的指令")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reportfiledb/database.py
+++ b/reportfiledb/database.py
@@ -1,0 +1,285 @@
+"""SQLite-backed storage layer for report snippets with hierarchical tagging."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Optional, Sequence, Set
+import sqlite3
+
+
+@dataclass(frozen=True)
+class Report:
+    """A container holding report metadata fetched from the database."""
+
+    id: int
+    title: str
+    content: str
+    created_at: datetime
+    source_path: Optional[str]
+
+
+@dataclass(frozen=True)
+class Tag:
+    """Representation of a tag including its parent-child relationship."""
+
+    id: int
+    name: str
+    parent_id: Optional[int]
+
+
+class ReportDatabase:
+    """Simple report storage database using SQLite."""
+
+    def __init__(self, path: Path | str = "reportdb.sqlite3") -> None:
+        self.path = Path(path)
+        self._ensure_schema()
+
+    # ------------------------------------------------------------------
+    # private helpers
+    def _ensure_schema(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS reports (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    title TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    source_path TEXT,
+                    created_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS tags (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL UNIQUE,
+                    parent_id INTEGER,
+                    FOREIGN KEY(parent_id) REFERENCES tags(id)
+                );
+
+                CREATE TABLE IF NOT EXISTS report_tags (
+                    report_id INTEGER NOT NULL,
+                    tag_id INTEGER NOT NULL,
+                    PRIMARY KEY (report_id, tag_id),
+                    FOREIGN KEY(report_id) REFERENCES reports(id) ON DELETE CASCADE,
+                    FOREIGN KEY(tag_id) REFERENCES tags(id) ON DELETE CASCADE
+                );
+                """
+            )
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        conn = sqlite3.connect(self.path)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+            conn.commit()
+        finally:
+            conn.close()
+
+    def _row_to_report(self, row: sqlite3.Row) -> Report:
+        return Report(
+            id=int(row["id"]),
+            title=row["title"],
+            content=row["content"],
+            created_at=datetime.fromisoformat(row["created_at"]),
+            source_path=row["source_path"],
+        )
+
+    def _resolve_tag_and_children(
+        self, conn: sqlite3.Connection, tag_name: str
+    ) -> Set[int]:
+        cursor = conn.execute("SELECT id FROM tags WHERE name = ?", (tag_name,))
+        row = cursor.fetchone()
+        if row is None:
+            return set()
+        tag_id = int(row["id"])
+        descendants: Set[int] = {tag_id}
+
+        queue = [tag_id]
+        while queue:
+            current = queue.pop()
+            child_cursor = conn.execute(
+                "SELECT id FROM tags WHERE parent_id = ?", (current,)
+            )
+            for child in child_cursor.fetchall():
+                child_id = int(child["id"])
+                if child_id not in descendants:
+                    descendants.add(child_id)
+                    queue.append(child_id)
+
+        return descendants
+
+    # ------------------------------------------------------------------
+    # public API
+    def add_report(
+        self,
+        title: str,
+        content: Optional[str] = None,
+        *,
+        source_path: Optional[Path | str] = None,
+        tags: Optional[Sequence[str]] = None,
+    ) -> int:
+        """Insert a new report entry and return its identifier."""
+
+        if content is None:
+            if source_path is None:
+                raise ValueError("Either content or source_path must be provided")
+            data = Path(source_path).read_text(encoding="utf-8")
+        else:
+            data = content
+
+        source_value = str(source_path) if source_path is not None else None
+        created_at = datetime.utcnow().isoformat(timespec="seconds")
+
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "INSERT INTO reports (title, content, source_path, created_at) VALUES (?, ?, ?, ?)",
+                (title, data, source_value, created_at),
+            )
+            report_id = int(cursor.lastrowid)
+
+            if tags:
+                for tag_name in tags:
+                    tag_id = self.ensure_tag(tag_name)
+                    conn.execute(
+                        "INSERT OR IGNORE INTO report_tags (report_id, tag_id) VALUES (?, ?)",
+                        (report_id, tag_id),
+                    )
+
+        return report_id
+
+    def ensure_tag(self, name: str, *, parent: Optional[str] = None) -> int:
+        """Return the identifier of ``name`` creating it (and parent) if missing."""
+
+        with self._connect() as conn:
+            parent_id: Optional[int] = None
+            if parent is not None:
+                parent_id = self.ensure_tag(parent)
+
+            cursor = conn.execute("SELECT id FROM tags WHERE name = ?", (name,))
+            row = cursor.fetchone()
+            if row:
+                tag_id = int(row["id"])
+                if parent_id is not None:
+                    conn.execute(
+                        "UPDATE tags SET parent_id = ? WHERE id = ?",
+                        (parent_id, tag_id),
+                    )
+                return tag_id
+
+            cursor = conn.execute(
+                "INSERT INTO tags (name, parent_id) VALUES (?, ?)", (name, parent_id)
+            )
+            return int(cursor.lastrowid)
+
+    def set_tag_parent(self, name: str, parent: Optional[str]) -> None:
+        """Explicitly set the parent of ``name`` to ``parent`` (creating parent if needed)."""
+
+        with self._connect() as conn:
+            cursor = conn.execute("SELECT id FROM tags WHERE name = ?", (name,))
+            row = cursor.fetchone()
+            if row is None:
+                raise ValueError(f"Tag '{name}' does not exist")
+
+            parent_id = None
+            if parent is not None:
+                parent_id = self.ensure_tag(parent)
+
+            conn.execute("UPDATE tags SET parent_id = ? WHERE id = ?", (parent_id, row["id"]))
+
+    def assign_tags(self, report_id: int, tag_names: Iterable[str]) -> None:
+        """Assign multiple tags to an existing report."""
+
+        with self._connect() as conn:
+            for name in tag_names:
+                tag_id = self.ensure_tag(name)
+                conn.execute(
+                    "INSERT OR IGNORE INTO report_tags (report_id, tag_id) VALUES (?, ?)",
+                    (report_id, tag_id),
+                )
+
+    def get_report(self, report_id: int) -> Report:
+        with self._connect() as conn:
+            cursor = conn.execute("SELECT * FROM reports WHERE id = ?", (report_id,))
+            row = cursor.fetchone()
+            if row is None:
+                raise ValueError(f"Report {report_id} does not exist")
+            return self._row_to_report(row)
+
+    def get_tags_for_report(self, report_id: int) -> List[Tag]:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                SELECT t.id, t.name, t.parent_id
+                FROM tags AS t
+                JOIN report_tags AS rt ON rt.tag_id = t.id
+                WHERE rt.report_id = ?
+                ORDER BY t.name
+                """,
+                (report_id,),
+            )
+            return [Tag(int(row["id"]), row["name"], row["parent_id"]) for row in cursor.fetchall()]
+
+    def list_reports(self) -> List[Report]:
+        with self._connect() as conn:
+            cursor = conn.execute("SELECT * FROM reports ORDER BY created_at DESC")
+            return [self._row_to_report(row) for row in cursor.fetchall()]
+
+    def list_tags(self) -> List[Tag]:
+        with self._connect() as conn:
+            cursor = conn.execute("SELECT id, name, parent_id FROM tags ORDER BY name")
+            return [Tag(int(row["id"]), row["name"], row["parent_id"]) for row in cursor.fetchall()]
+
+    def search_reports(self, tag_names: Sequence[str]) -> List[Report]:
+        """Return reports that contain *all* of the provided ``tag_names``.
+
+        Each tag expands to include its descendants, mimicking a tag tree similar
+        to what Danbooru offers.
+        """
+
+        if not tag_names:
+            return self.list_reports()
+
+        with self._connect() as conn:
+            tag_id_sets = [self._resolve_tag_and_children(conn, name) for name in tag_names]
+            if any(not ids for ids in tag_id_sets):
+                return []
+
+            subqueries: List[str] = []
+            params: List[int] = []
+            for ids in tag_id_sets:
+                placeholders = ",".join("?" * len(ids))
+                subqueries.append(
+                    f"SELECT DISTINCT report_id FROM report_tags WHERE tag_id IN ({placeholders})"
+                )
+                params.extend(ids)
+
+            intersect_sql = " INTERSECT ".join(subqueries)
+            query = f"SELECT r.* FROM reports AS r WHERE r.id IN ({intersect_sql}) ORDER BY r.created_at DESC"
+            cursor = conn.execute(query, params)
+            return [self._row_to_report(row) for row in cursor.fetchall()]
+
+    # Convenience -----------------------------------------------------------------
+    def build_tag_tree(self) -> Dict[Optional[int], List[Tag]]:
+        """Return a mapping from parent_id to a list of children tags."""
+
+        with self._connect() as conn:
+            cursor = conn.execute("SELECT id, name, parent_id FROM tags")
+            tree: Dict[Optional[int], List[Tag]] = {}
+            for row in cursor.fetchall():
+                tag = Tag(int(row["id"]), row["name"], row["parent_id"])
+                tree.setdefault(tag.parent_id, []).append(tag)
+            for children in tree.values():
+                children.sort(key=lambda t: t.name)
+            return tree
+
+    def export_report(self, report_id: int, destination: Path | str) -> Path:
+        """Write the report content to ``destination`` and return the path."""
+
+        report = self.get_report(report_id)
+        dest_path = Path(destination)
+        dest_path.write_text(report.content, encoding="utf-8")
+        return dest_path

--- a/reportfiledb/gui.py
+++ b/reportfiledb/gui.py
@@ -1,0 +1,309 @@
+"""Tkinter GUI for ReportFileDB."""
+
+from __future__ import annotations
+
+import argparse
+import tkinter as tk
+from dataclasses import dataclass
+from tkinter import messagebox, simpledialog, ttk
+from typing import Dict, Optional
+
+from .database import Report, ReportDatabase, Tag
+
+
+@dataclass
+class _TagNode:
+    item_id: str
+    tag: Optional[Tag]
+
+
+class ReportApp:
+    """Main application window for browsing and editing reports."""
+
+    def __init__(self, root: tk.Tk, *, database: str = "reportdb.sqlite3") -> None:
+        self.root = root
+        self.root.title("ReportFileDB")
+        self.db = ReportDatabase(database)
+
+        self._tag_nodes: Dict[str, _TagNode] = {}
+        self._reports: list[Report] = []
+
+        self._build_ui()
+        self._populate_tags()
+        self._load_reports(None)
+
+    # ------------------------------------------------------------------
+    # UI 建立
+    def _build_ui(self) -> None:
+        self.root.geometry("1000x600")
+        self.root.minsize(900, 500)
+
+        paned = ttk.PanedWindow(self.root, orient=tk.HORIZONTAL)
+        paned.pack(fill=tk.BOTH, expand=True)
+
+        # 左側：標籤樹
+        tag_frame = ttk.Frame(paned)
+        paned.add(tag_frame, weight=1)
+
+        tag_header = ttk.Label(tag_frame, text="標籤")
+        tag_header.pack(anchor=tk.W, padx=8, pady=(8, 4))
+
+        self.tag_tree = ttk.Treeview(tag_frame, show="tree")
+        self.tag_tree.pack(fill=tk.BOTH, expand=True, padx=8, pady=(0, 8))
+        self.tag_tree.bind("<<TreeviewSelect>>", self._on_tag_selected)
+
+        tag_buttons = ttk.Frame(tag_frame)
+        tag_buttons.pack(fill=tk.X, padx=8, pady=(0, 8))
+
+        ttk.Button(tag_buttons, text="新增標籤", command=self._add_tag).pack(side=tk.LEFT)
+        ttk.Button(tag_buttons, text="重新整理", command=self._populate_tags).pack(side=tk.LEFT, padx=(8, 0))
+
+        # 右側：報告與內容
+        right_frame = ttk.Frame(paned)
+        paned.add(right_frame, weight=3)
+
+        report_header = ttk.Label(right_frame, text="報告清單")
+        report_header.pack(anchor=tk.W, padx=8, pady=(8, 4))
+
+        self.report_list = tk.Listbox(right_frame, exportselection=False)
+        self.report_list.pack(fill=tk.BOTH, expand=False, padx=8, pady=(0, 8))
+        self.report_list.bind("<<ListboxSelect>>", self._on_report_selected)
+        self.report_list.configure(height=10)
+
+        button_bar = ttk.Frame(right_frame)
+        button_bar.pack(fill=tk.X, padx=8, pady=(0, 8))
+
+        ttk.Button(button_bar, text="新增報告", command=self._add_report).pack(side=tk.LEFT)
+        ttk.Button(button_bar, text="匯出報告", command=self._export_report).pack(side=tk.LEFT, padx=(8, 0))
+        ttk.Button(button_bar, text="重新整理", command=self._refresh_data).pack(side=tk.LEFT, padx=(8, 0))
+
+        detail_header = ttk.Label(right_frame, text="報告內容")
+        detail_header.pack(anchor=tk.W, padx=8, pady=(0, 4))
+
+        detail_container = ttk.Frame(right_frame)
+        detail_container.pack(fill=tk.BOTH, expand=True, padx=8, pady=(0, 8))
+
+        self.detail_text = tk.Text(detail_container, wrap=tk.WORD)
+        self.detail_text.pack(fill=tk.BOTH, expand=True)
+        self.detail_text.configure(state=tk.DISABLED)
+
+        self.status_var = tk.StringVar(value="共 0 筆報告")
+        status_bar = ttk.Label(self.root, textvariable=self.status_var, anchor=tk.W)
+        status_bar.pack(fill=tk.X)
+
+    # ------------------------------------------------------------------
+    # 資料載入
+    def _populate_tags(self) -> None:
+        self.tag_tree.delete(*self.tag_tree.get_children())
+        self._tag_nodes.clear()
+
+        root_id = self.tag_tree.insert("", tk.END, text="全部報告")
+        self._tag_nodes[root_id] = _TagNode(item_id=root_id, tag=None)
+
+        tree = self.db.build_tag_tree()
+
+        def add_children(parent_item: str, parent_tag_id: Optional[int]) -> None:
+            for tag in tree.get(parent_tag_id, []):
+                item = self.tag_tree.insert(parent_item, tk.END, text=tag.name)
+                self._tag_nodes[item] = _TagNode(item_id=item, tag=tag)
+                add_children(item, tag.id)
+
+        add_children(root_id, None)
+        self.tag_tree.item(root_id, open=True)
+        self.tag_tree.selection_set(root_id)
+
+    def _load_reports(self, tag: Optional[Tag]) -> None:
+        if tag is None:
+            reports = self.db.list_reports()
+        else:
+            reports = self.db.search_reports([tag.name])
+
+        self._reports = reports
+        self.report_list.delete(0, tk.END)
+        for report in reports:
+            created = report.created_at.strftime("%Y-%m-%d %H:%M")
+            self.report_list.insert(tk.END, f"[{report.id}] {report.title} - {created}")
+
+        self.status_var.set(f"共 {len(reports)} 筆報告")
+        self.detail_text.configure(state=tk.NORMAL)
+        self.detail_text.delete("1.0", tk.END)
+        self.detail_text.configure(state=tk.DISABLED)
+
+    # ------------------------------------------------------------------
+    # 事件處理
+    def _on_tag_selected(self, event: tk.Event) -> None:
+        selection = self.tag_tree.selection()
+        if not selection:
+            return
+        node = self._tag_nodes.get(selection[0])
+        tag = node.tag if node else None
+        self._load_reports(tag)
+
+    def _on_report_selected(self, _: tk.Event) -> None:
+        selection = self.report_list.curselection()
+        if not selection:
+            return
+        index = selection[0]
+        if index >= len(self._reports):
+            return
+        report = self._reports[index]
+        tags = ", ".join(tag.name for tag in self.db.get_tags_for_report(report.id)) or "<無標籤>"
+        created = report.created_at.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+        detail_lines = [
+            f"標題：{report.title}",
+            f"建立時間：{created}",
+            f"來源：{report.source_path or '-'}",
+            f"標籤：{tags}",
+            "",
+            report.content,
+        ]
+
+        self.detail_text.configure(state=tk.NORMAL)
+        self.detail_text.delete("1.0", tk.END)
+        self.detail_text.insert("1.0", "\n".join(detail_lines))
+        self.detail_text.configure(state=tk.DISABLED)
+
+    # ------------------------------------------------------------------
+    # 動作
+    def _refresh_data(self) -> None:
+        selection = self.tag_tree.selection()
+        tag = None
+        if selection:
+            node = self._tag_nodes.get(selection[0])
+            tag = node.tag if node else None
+        self._load_reports(tag)
+
+    def _add_tag(self) -> None:
+        name = simpledialog.askstring("新增標籤", "請輸入標籤名稱：", parent=self.root)
+        if not name:
+            return
+
+        parent_tag: Optional[Tag] = None
+        selection = self.tag_tree.selection()
+        if selection:
+            node = self._tag_nodes.get(selection[0])
+            if node and node.tag:
+                parent_tag = node.tag
+
+        try:
+            parent_name = parent_tag.name if parent_tag else None
+            self.db.ensure_tag(name, parent=parent_name)
+        except Exception as exc:  # pragma: no cover - GUI 錯誤顯示
+            messagebox.showerror("新增標籤失敗", str(exc), parent=self.root)
+            return
+
+        self._populate_tags()
+        messagebox.showinfo("完成", f"標籤 '{name}' 已建立", parent=self.root)
+
+    def _add_report(self) -> None:
+        dialog = _ReportDialog(self.root)
+        self.root.wait_window(dialog.window)
+        if not dialog.result:
+            return
+
+        title, content, tags = dialog.result
+        try:
+            report_id = self.db.add_report(title, content, tags=tags)
+        except Exception as exc:  # pragma: no cover - GUI 錯誤顯示
+            messagebox.showerror("新增報告失敗", str(exc), parent=self.root)
+            return
+
+        self._refresh_data()
+        messagebox.showinfo("完成", f"報告 #{report_id} 已新增", parent=self.root)
+
+    def _export_report(self) -> None:
+        selection = self.report_list.curselection()
+        if not selection:
+            messagebox.showwarning("請先選擇報告", "請在清單中選擇要匯出的報告。", parent=self.root)
+            return
+        report = self._reports[selection[0]]
+
+        filename = simpledialog.askstring(
+            "匯出報告", "請輸入輸出檔名 (例如 output.txt)：", parent=self.root
+        )
+        if not filename:
+            return
+
+        try:
+            path = self.db.export_report(report.id, filename)
+        except Exception as exc:  # pragma: no cover - GUI 錯誤顯示
+            messagebox.showerror("匯出失敗", str(exc), parent=self.root)
+            return
+
+        messagebox.showinfo("完成", f"已匯出至 {path}", parent=self.root)
+
+
+class _ReportDialog:
+    """簡易彈窗，讓使用者輸入報告內容。"""
+
+    def __init__(self, parent: tk.Tk):
+        self.window = tk.Toplevel(parent)
+        self.window.title("新增報告")
+        self.window.grab_set()
+        self.window.transient(parent)
+
+        ttk.Label(self.window, text="標題").grid(row=0, column=0, sticky=tk.W, padx=8, pady=(8, 4))
+        self.title_var = tk.StringVar()
+        ttk.Entry(self.window, textvariable=self.title_var).grid(
+            row=0, column=1, sticky=tk.EW, padx=8, pady=(8, 4)
+        )
+
+        ttk.Label(self.window, text="內容").grid(row=1, column=0, sticky=tk.NW, padx=8, pady=4)
+        self.content_text = tk.Text(self.window, width=60, height=15, wrap=tk.WORD)
+        self.content_text.grid(row=1, column=1, sticky=tk.NSEW, padx=8, pady=4)
+
+        ttk.Label(self.window, text="標籤 (以逗號分隔)").grid(
+            row=2, column=0, sticky=tk.W, padx=8, pady=4
+        )
+        self.tags_var = tk.StringVar()
+        ttk.Entry(self.window, textvariable=self.tags_var).grid(
+            row=2, column=1, sticky=tk.EW, padx=8, pady=4
+        )
+
+        button_bar = ttk.Frame(self.window)
+        button_bar.grid(row=3, column=0, columnspan=2, sticky=tk.E, padx=8, pady=(4, 8))
+        ttk.Button(button_bar, text="取消", command=self.window.destroy).pack(side=tk.RIGHT)
+        ttk.Button(button_bar, text="新增", command=self._on_submit).pack(side=tk.RIGHT, padx=(0, 8))
+
+        self.window.columnconfigure(1, weight=1)
+        self.window.rowconfigure(1, weight=1)
+
+        self.result: Optional[tuple[str, str, list[str]]] = None
+
+    def _on_submit(self) -> None:
+        title = self.title_var.get().strip()
+        content = self.content_text.get("1.0", tk.END).strip()
+        tags_text = self.tags_var.get().strip()
+
+        if not title:
+            messagebox.showwarning("缺少標題", "請輸入報告標題。", parent=self.window)
+            return
+        if not content:
+            messagebox.showwarning("缺少內容", "請輸入報告內容。", parent=self.window)
+            return
+
+        tags = [tag.strip() for tag in tags_text.split(",") if tag.strip()] if tags_text else []
+        self.result = (title, content, tags)
+        self.window.destroy()
+
+
+def launch(database: str = "reportdb.sqlite3") -> None:
+    root = tk.Tk()
+    ReportApp(root, database=database)
+    root.mainloop()
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="ReportFileDB 圖形介面")
+    parser.add_argument(
+        "--database",
+        default="reportdb.sqlite3",
+        help="資料庫檔案路徑 (預設: reportdb.sqlite3)",
+    )
+    args = parser.parse_args(argv)
+    launch(args.database)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Tkinter-based GUI with tag tree and report detail panes for interacting with the report database
- expose a python -m entry point via reportdb_gui.py
- document GUI usage in the README

## Testing
- python -m reportdb_gui --help

------
https://chatgpt.com/codex/tasks/task_e_68dce96ebe28832aa357f26e997f1724