### PR TITLE
Handle invalid UTF-8 when importing report files

### DIFF
--- a/reportfiledb/cli.py
+++ b/reportfiledb/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Iterable, List, Optional, Tuple
 
 from .database import ReportDatabase
+from .utils import read_text_with_fallback
 
 
 def _print_report(report_db: ReportDatabase, report_id: int, *, show_content: bool) -> None:
@@ -177,7 +178,11 @@ def _read_content_and_source(
     if args.content is not None:
         return args.content, None, False
     if args.file is not None:
-        return args.file.read_text(encoding="utf-8"), str(args.file), True
+        try:
+            text = read_text_with_fallback(args.file)
+        except OSError as exc:
+            raise SystemExit(f"無法讀取檔案: {exc}") from exc
+        return text, str(args.file), True
     if getattr(args, "stdin", False):
         return sys.stdin.read(), None, False
     if optional:

--- a/reportfiledb/database.py
+++ b/reportfiledb/database.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import Dict, Iterable, Iterator, List, Optional, Sequence, Set
 import sqlite3
 
+from .utils import read_text_with_fallback
+
 
 @dataclass(frozen=True)
 class Report:
@@ -127,7 +129,7 @@ class ReportDatabase:
         if content is None:
             if source_path is None:
                 raise ValueError("Either content or source_path must be provided")
-            data = Path(source_path).read_text(encoding="utf-8")
+            data = read_text_with_fallback(Path(source_path))
         else:
             data = content
 

--- a/reportfiledb/gui.py
+++ b/reportfiledb/gui.py
@@ -9,9 +9,8 @@ from dataclasses import dataclass
 from tkinter import filedialog, messagebox, simpledialog, ttk
 from typing import Dict, Optional, Sequence
 
-
-
 from .database import Report, ReportDatabase, Tag
+from .utils import read_text_with_fallback
 
 
 @dataclass
@@ -625,7 +624,7 @@ class _ReportDialog:
             return
         path = Path(filename)
         try:
-            data = path.read_text(encoding="utf-8")
+            data = read_text_with_fallback(path)
         except Exception as exc:  # pragma: no cover - GUI 錯誤顯示
             messagebox.showerror("讀取檔案失敗", str(exc), parent=self.window)
             return

--- a/reportfiledb/utils.py
+++ b/reportfiledb/utils.py
@@ -1,0 +1,22 @@
+"""輔助函式集合。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def read_text_with_fallback(path: Path, *, encoding: str = "utf-8") -> str:
+    """以 UTF-8 讀取 ``path``，必要時以替代策略避免解碼失敗。
+
+    由於部分匯入的報告檔案可能含有非標準的位元組序列或雜訊，
+    直接以 :func:`Path.read_text` 讀取時會觸發 ``UnicodeDecodeError``。
+    此函式先嘗試以標準 UTF-8 解碼，若失敗則回退為逐位元組
+    讀取並以 ``errors="replace"`` 方式解碼，確保能得到字串內容，
+    同時保留問題位元組的資訊（以 � 代表）。
+    """
+
+    try:
+        return path.read_text(encoding=encoding)
+    except UnicodeDecodeError:
+        data = path.read_bytes()
+        return data.decode(encoding, errors="replace")


### PR DESCRIPTION
## Summary
- add a shared helper to read text files with a UTF-8 fallback strategy
- use the helper from the database, CLI, and GUI to avoid crashes when files contain invalid bytes

## Testing
- python -m compileall reportfiledb

------
https://chatgpt.com/codex/tasks/task_e_68de35428944832aadbf4d956e7d8369