### PR TITLE
修正從檔案載入的覆寫行為與編碼讀取錯誤

### DIFF
--- a/reportfiledb/gui.py
+++ b/reportfiledb/gui.py
@@ -624,13 +624,11 @@ class _ReportDialog:
             return
         path = Path(filename)
         try:
-            data = read_text_with_fallback(path)
+            read_text_with_fallback(path)
         except Exception as exc:  # pragma: no cover - GUI 錯誤顯示
             messagebox.showerror("讀取檔案失敗", str(exc), parent=self.window)
             return
 
-        self.content_text.delete("1.0", tk.END)
-        self.content_text.insert("1.0", data)
         self.source_var.set(str(path))
 
         if self.clear_source_var is not None:

--- a/reportfiledb/utils.py
+++ b/reportfiledb/utils.py
@@ -67,19 +67,7 @@ def read_text_with_fallback(
 
     會優先使用 ``encoding``，若失敗則依序測試 ``candidates`` 與常見的
     Unicode / 中文編碼（例如 Big5 / CP950、GB18030）。全部失敗時，
-    最後會以 ``errors="replace"`` 回傳，避免拋出例外。"""
-
-from pathlib import Path
-
-
-def read_text_with_fallback(path: Path, *, encoding: str = "utf-8") -> str:
-    """以 UTF-8 讀取 ``path``，必要時以替代策略避免解碼失敗。
-
-    由於部分匯入的報告檔案可能含有非標準的位元組序列或雜訊，
-    直接以 :func:`Path.read_text` 讀取時會觸發 ``UnicodeDecodeError``。
-    此函式先嘗試以標準 UTF-8 解碼，若失敗則回退為逐位元組
-    讀取並以 ``errors="replace"`` 方式解碼，確保能得到字串內容，
-    同時保留問題位元組的資訊（以 � 代表）。
+    最後會以 ``errors="replace"`` 回傳，避免拋出例外。
     """
 
     try:


### PR DESCRIPTION
## Summary
- 重構 `read_text_with_fallback`，保留候選編碼流程並修正未定義變數造成的例外
- 調整 GUI 的「從檔案載入」按鈕僅更新來源路徑，避免自動覆寫內容區

## Testing
- python -m compileall reportfiledb

------
https://chatgpt.com/codex/tasks/task_e_68de3f7eb854832aa951954dc647e046